### PR TITLE
ISNS bugfixing and debugging enhancements

### DIFF
--- a/common/include/constants.h
+++ b/common/include/constants.h
@@ -52,17 +52,21 @@ constexpr size_t ivsense_channel_vin = 6;   // Supply voltage channel index
 
 constexpr float ivsense_voltage_ratio = (2.21e3f + 39.2e3f) / 2.21e3f;      // Ratio of actual voltage to ADC input voltage
 constexpr float ivsense_current_shunt_value = 0.01f;                        // Current shunt resistor value, ohms
-constexpr float ivsense_current_amp_gain = 41.2f;                           // Current shunt amplifier gain, V/V
-constexpr float ivsense_current_amp_offset = 0.02f;                         // Voltage offset pre-gain (to handle negative currents)
+constexpr float ivsense_current_amp_input_divider_gain = 0.97209f;          // Ratio of the input divider to the isns amp
+constexpr float ivsense_current_amp_gain = 43.1f;                           // Current shunt amplifier gain, V/V
+constexpr float ivsense_current_amp_composite_gain = ivsense_current_amp_input_divider_gain*ivsense_current_amp_gain;
+constexpr float ivsense_current_amp_offset = 0.03366f;                      // Voltage offset pre-gain (to handle negative currents)
 constexpr float adc_vref_voltage = 3.3f;                                    // ADC reference voltage, volts
 constexpr unsigned int adc_max_value = 1u << 12;                            // ADC maximum value
+constexpr float adc_v_per_count = adc_vref_voltage / adc_max_value;
+
 constexpr float max_duty_cycle (0.9f); // Maximum allowable duty cycle before gate on-time interferes with ADC sampling
 
 /* Maximum expected voltage measurement */
 constexpr float ivsense_voltage_max = adc_vref_voltage * ivsense_voltage_ratio;
 
 /* Maximum expected current measurement */
-constexpr float ivsense_current_max = (1.0f / ivsense_current_shunt_value) * ((1.0f / ivsense_current_amp_gain) * adc_vref_voltage - ivsense_current_amp_offset);
+constexpr float ivsense_current_max = (1.0f / ivsense_current_shunt_value) * ((1.0f / ivsense_current_amp_composite_gain) * adc_vref_voltage - ivsense_current_amp_offset);
 
 /* Current at zero volts (also the minimum) */
 constexpr float ivsense_current_zero_voltage = (1.0f / ivsense_current_shunt_value) * (-ivsense_current_amp_offset);
@@ -74,7 +78,9 @@ constexpr float ivsense_voltage_zero_current = ivsense_current_amp_gain * (ivsen
 constexpr float ivsense_voltage_per_count = ivsense_voltage_max / adc_max_value;
 
 /* Actual current per ADC count */
-constexpr float ivsense_current_per_count = (ivsense_current_max - ivsense_current_zero_voltage) / adc_max_value;
+// BUG HERE! This formula assumes the reference current is exactly halfway between the rails, which it isnt'.
+//constexpr float ivsense_current_per_count = (ivsense_current_max - ivsense_current_zero_voltage) / adc_max_value;
+constexpr float ivsense_current_per_count = adc_v_per_count / (ivsense_current_amp_composite_gain*ivsense_current_shunt_value);
 
 /* ADC Value zero current is centered on */
 constexpr float ivsense_count_zero_current = ivsense_voltage_zero_current / adc_vref_voltage * adc_max_value;

--- a/common/include/constants.h
+++ b/common/include/constants.h
@@ -102,6 +102,7 @@ constexpr uint8_t control_mode_torque = 2;
 constexpr uint8_t control_mode_velocity = 3;
 constexpr uint8_t control_mode_position = 4;
 constexpr uint8_t control_mode_position_velocity = 5;
+constexpr uint8_t control_mode_fixed_ang_vel = 6;
 
 /* Encoder modes */
 constexpr uint8_t encoder_mode_none = 0;

--- a/common/include/constants.h
+++ b/common/include/constants.h
@@ -24,9 +24,10 @@ constexpr float rad_per_enc_tick = -2.0f * pi / encoder_period;
 
 constexpr unsigned int motor_pwm_clock_freq = 168000000; // Hz
 
-constexpr unsigned int motor_pwm_cycle_freq = 40000; // Hz
+constexpr unsigned int motor_pwm_cycle_freq = 20000; // Hz
 
-constexpr unsigned int adc_pwm_cycle_freq = motor_pwm_clock_freq / 2; // Hz
+// TIM3 can't handle the full 168MHz like TIM1
+constexpr unsigned int adc_pwm_cycle_freq = motor_pwm_clock_freq/2; // Hz
 
 constexpr float current_control_freq = motor_pwm_cycle_freq / 2.0f; // Current control runs every two PWM cycles
 constexpr float current_control_interval = 1.0f / current_control_freq;
@@ -41,12 +42,12 @@ constexpr size_t ivsense_sample_buf_depth = ivsense_samples_per_cycle * 2; // "d
 
 constexpr size_t ivsense_channel_count = 7; // 4 voltage channels, 3 current channels
 
-constexpr size_t ivsense_channel_vc = 0;    // Phase A current channel index
-constexpr size_t ivsense_channel_vb = 1;    // Phase B current channel index
-constexpr size_t ivsense_channel_va = 2;    // Phase C current channel index
-constexpr size_t ivsense_channel_ia = 3;    // Phase A voltage channel index
-constexpr size_t ivsense_channel_ib = 4;    // Phase B voltage channel index
-constexpr size_t ivsense_channel_ic = 5;    // Phase C voltage channel index
+constexpr size_t ivsense_channel_ia = 0;    // Phase A current channel index
+constexpr size_t ivsense_channel_ib = 1;    // Phase B current channel index
+constexpr size_t ivsense_channel_ic = 2;    // Phase C current channel index
+constexpr size_t ivsense_channel_va = 3;    // Phase A voltage channel index
+constexpr size_t ivsense_channel_vb = 4;    // Phase B voltage channel index
+constexpr size_t ivsense_channel_vc = 5;    // Phase C voltage channel index
 constexpr size_t ivsense_channel_vin = 6;   // Supply voltage channel index
 
 constexpr float ivsense_voltage_ratio = (2.21e3f + 39.2e3f) / 2.21e3f;      // Ratio of actual voltage to ADC input voltage

--- a/common/include/constants.h
+++ b/common/include/constants.h
@@ -56,6 +56,7 @@ constexpr float ivsense_current_amp_gain = 41.2f;                           // C
 constexpr float ivsense_current_amp_offset = 0.02f;                         // Voltage offset pre-gain (to handle negative currents)
 constexpr float adc_vref_voltage = 3.3f;                                    // ADC reference voltage, volts
 constexpr unsigned int adc_max_value = 1u << 12;                            // ADC maximum value
+constexpr float max_duty_cycle (0.9f); // Maximum allowable duty cycle before gate on-time interferes with ADC sampling
 
 /* Maximum expected voltage measurement */
 constexpr float ivsense_voltage_max = adc_vref_voltage * ivsense_voltage_ratio;

--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -274,3 +274,6 @@ upload: build/$(PROJECT).bin
 		verify_image build/$(PROJECT).bin 0x08008000;\
 		reset run;\
 		shutdown"
+
+debug: build/$(PROJECT).elf
+	./run_gdb.sh

--- a/firmware/gdbinit.txt
+++ b/firmware/gdbinit.txt
@@ -1,0 +1,7 @@
+directory .
+monitor reset halt
+set mem inaccessible-by-default off
+set print pretty
+load
+lay src
+

--- a/firmware/openocd_gdb.cfg
+++ b/firmware/openocd_gdb.cfg
@@ -5,6 +5,9 @@ transport select "hla_swd"
 set ENABLE_LOW_POWER 1
 set STOP_WATCHDOG 1
 set CONNECT_UNDER_RESET 1
+set CLOCK_FREQ 4000
+
+reset_config srst_only srst_nogate connect_assert_srst
 
 source [find target/stm32f4x.cfg]
 
@@ -12,4 +15,5 @@ source [find target/stm32f4x.cfg]
 $_TARGETNAME configure -rtos ChibiOS
 gdb_flash_program enable
 gdb_memory_map enable
+gdb_breakpoint_override hard
 

--- a/firmware/openocd_gdb.cfg
+++ b/firmware/openocd_gdb.cfg
@@ -1,0 +1,15 @@
+source [find interface/stlink-v2.cfg]
+set CHIPNAME STM32F405RG
+
+transport select "hla_swd"
+set ENABLE_LOW_POWER 1
+set STOP_WATCHDOG 1
+set CONNECT_UNDER_RESET 1
+
+source [find target/stm32f4x.cfg]
+
+# Debugger
+$_TARGETNAME configure -rtos ChibiOS
+gdb_flash_program enable
+gdb_memory_map enable
+

--- a/firmware/openocd_pipe.sh
+++ b/firmware/openocd_pipe.sh
@@ -1,0 +1,6 @@
+# This file is not meant to be run directly by the user, it is called by gdb
+set -m
+trap '' INT
+
+openocd -c "gdb_port pipe" -f "openocd_gdb.cfg" -l /dev/null
+

--- a/firmware/run_gdb.sh
+++ b/firmware/run_gdb.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+GDB_LINK="https://developer.arm.com/-/media/Files/downloads/gnu-rm/8-2018q4/gcc-arm-none-eabi-8-2018-q4-major-linux.tar.bz2?revision=d830f9dd-cd4f-406d-8672-cca9210dd220?product=GNU%20Arm%20Embedded%20Toolchain,64-bit,,Linux,8-2018-q4-major"
+GDB=arm-none-eabi-gdb
+
+if ! [ -x "$(command -v $GDB)" ] ; then
+  echo "$GDB is missing.  You can download it here:"
+  echo $GDB_LINK
+fi
+
+set -e
+
+PWD=`pwd`
+
+$GDB $PWD/build/motor_controller.elf \
+  -ex "target extended-remote | $PWD/openocd_pipe.sh" \
+  -x gdbinit.txt
+#  -ex "directory ." \

--- a/firmware/run_gdb.sh
+++ b/firmware/run_gdb.sh
@@ -2,10 +2,19 @@
 
 GDB_LINK="https://developer.arm.com/-/media/Files/downloads/gnu-rm/8-2018q4/gcc-arm-none-eabi-8-2018-q4-major-linux.tar.bz2?revision=d830f9dd-cd4f-406d-8672-cca9210dd220?product=GNU%20Arm%20Embedded%20Toolchain,64-bit,,Linux,8-2018-q4-major"
 GDB=arm-none-eabi-gdb
+GCC=arm-none-eabi-gcc
 
 if ! [ -x "$(command -v $GDB)" ] ; then
   echo "$GDB is missing.  You can download it here:"
   echo $GDB_LINK
+  if [ -x "$(command -v $GCC)" ] ; then
+    echo "WARNING: $GCC is present but $GDB isn't, this probably means you installed the arm-none-eabi suite from apt."
+    echo "You must uninstall the arm-none-eabi suite from apt, then install the one linked above"
+    echo "Uninstalling should be as straightforward as:"
+    echo "sudo apt remove gcc-arm-none-eabi binutils-arm-none-eabi"
+  fi
+  echo "Can't continue until proper tools installed"
+  exit 1
 fi
 
 set -e
@@ -15,4 +24,4 @@ PWD=`pwd`
 $GDB $PWD/build/motor_controller.elf \
   -ex "target extended-remote | $PWD/openocd_pipe.sh" \
   -x gdbinit.txt
-#  -ex "directory ." \
+

--- a/firmware/src/control.cpp
+++ b/firmware/src/control.cpp
@@ -221,6 +221,11 @@ void runVelocityControl() {
   }
 }
 
+static void setScaledDuty(uint8_t phase, float duty) {
+  // Scale the duty cycle to prevent interference of gate on-time with ADC sampling
+  gate_driver.setPWMDutyCycle(phase, duty*max_duty_cycle);
+}
+
 void runCurrentControl() {
   /*
    * Compute phase duty cycles
@@ -231,9 +236,25 @@ void runCurrentControl() {
      * Directly set PWM duty cycles
      */
 
-    gate_driver.setPWMDutyCycle(0, parameters.phase0);
-    gate_driver.setPWMDutyCycle(1, parameters.phase1);
-    gate_driver.setPWMDutyCycle(2, parameters.phase2);
+    setScaledDuty(0, parameters.phase0);
+    setScaledDuty(1, parameters.phase1);
+    setScaledDuty(2, parameters.phase2);
+  } else if (parameters.control_mode == control_mode_fixed_ang_vel) {
+    // FIXED ANGULAR VEL TEST
+    // This is a hack to bypass all feedback and just slowly spin a motor
+    static float ang = 0.0f;
+    // At 40kHz this is 1 rev/second
+    static const float d_ang = 0.000157;
+    static const float erev_per_s = 28;
+    static const float duty = 0.5;
+    static const float phase_gap = 2*pi/3;
+    ang += d_ang*erev_per_s;
+    while(ang>2*pi) {
+      ang -= 2*pi;
+    }
+    for(int i = 0; i < 3; i++) {
+      setScaledDuty(i,duty*0.5*(1+fast_sin(ang+(i*phase_gap))));
+    }
   } else {
     /*
      * Run field-oriented control
@@ -301,9 +322,9 @@ void runCurrentControl() {
     float duty0, duty1, duty2;
     modulator.computeDutyCycles(valpha_norm, vbeta_norm, duty0, duty1, duty2);
 
-    gate_driver.setPWMDutyCycle(0, duty0);
-    gate_driver.setPWMDutyCycle(1, duty1);
-    gate_driver.setPWMDutyCycle(2, duty2);
+    setScaledDuty(0, duty0);
+    setScaledDuty(1, duty1);
+    setScaledDuty(2, duty2);
 
     results.foc_d_current = id;
     results.foc_q_current = iq;


### PR DESCRIPTION
Changes PWMing scheme to guarantee that ADC sampling does not collide with gate driver HIGH.
- Center-aligned to edge-aligned pwm
- ADC sequence changed to prioritize ISNS channels early
- ADC sequence starts at beginning of gate driver LOW instead of in the middle

Corrections to conversion equations for reading ISNS currents
- Fixes 1.5A offset that was in previous data
- The current appears to still have a ~100mA offset, will need to double check equations

Adds support for "make debug" in the firmware directory, which attaches GDB to the driver board.